### PR TITLE
Potential fix for code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -478,4 +478,5 @@ def index():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=PORT, debug=True)
+    debug_mode = os.environ.get("FLASK_DEBUG", "").lower() in {"1", "true", "yes"}
+    app.run(host="0.0.0.0", port=PORT, debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/adhatcher/schwinn_stationary_bike/security/code-scanning/1](https://github.com/adhatcher/schwinn_stationary_bike/security/code-scanning/1)

In general, Flask applications should not enable `debug=True` in code that might run in production. Instead, debug mode should either be disabled entirely in the `app.run` call or controlled via configuration (typically an environment variable) so that production environments run with debug disabled.

The best minimal fix here is to remove the hard‑coded `debug=True` from `app.run` and, if desired, make debug configurable through an environment variable while defaulting to `False`. This preserves existing functionality for developers who can opt in to debugging but ensures that any default execution (for example, `python app.py` on a server) does not run with debug enabled. Concretely, in `app/app.py` around line 480, replace the `app.run` invocation with one that computes a `debug` flag based on `os.environ.get("FLASK_DEBUG")` (or similar) and passes that flag into `app.run`. No new third‑party imports are needed, since `os` is already imported at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/adhatcher/schwinn_stationary_bike/9?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->