### PR TITLE
Updating workflow to only publish images on merge into master.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,10 @@
 name: Build and Deploy
 
 on:
+  pull_request:
+  push:
+    branches-ignore:
+      - master
   workflow_run:
     workflows:
       - CI
@@ -14,6 +18,32 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  build-only:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5.0.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.12.0
+
+      - name: Build Docker image without publishing
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   build-and-push:
     if: >
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
# Updated workflow

PR opened/updated        -> build Docker image only, no publish
Push to lower branch     -> build Docker image only, no publish
Merge/push to master     -> CI runs
CI success on master     -> build and publish Docker image
Manual workflow dispatch -> build and publish Docker image