### PR TITLE
[codex] Show last 30 day workouts on welcome dashboard

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -932,6 +932,33 @@ def build_summary_cards(df: pd.DataFrame) -> dict[str, dict[str, str]]:
     }
 
 
+def build_last_30_day_workouts(df: pd.DataFrame, *, today: pd.Timestamp | None = None) -> list[dict[str, str]]:
+    """Build display rows for workouts included in the last 30-day summary."""
+    if df.empty:
+        return []
+
+    if today is None:
+        today = current_day()
+    else:
+        today = pd.to_datetime(today).normalize()
+
+    window_start = today - pd.Timedelta(days=29)
+    recent_df = df[(df["Workout_Date"] >= window_start) & (df["Workout_Date"] <= today)]
+    recent_df = recent_df.sort_values(by=["Workout_Date"], ascending=False)
+    rows = []
+    for _, workout in recent_df.iterrows():
+        rows.append(
+            {
+                "date": pd.to_datetime(workout["Workout_Date"]).date().isoformat(),
+                "time": format_minutes(int(pd.to_numeric(workout["Workout_Time"], errors="coerce"))),
+                "distance": format_distance(float(pd.to_numeric(workout["Distance"], errors="coerce"))),
+                "average_speed": format_distance(float(pd.to_numeric(workout["Avg_Speed"], errors="coerce"))),
+                "total_calories": format_distance(float(pd.to_numeric(workout["Total_Calories"], errors="coerce"))),
+            }
+        )
+    return rows
+
+
 def build_page_context(historical_data: pd.DataFrame) -> dict[str, object]:
     """Build shared page context from workout history."""
     min_date = ""
@@ -956,6 +983,7 @@ def build_page_context(historical_data: pd.DataFrame) -> dict[str, object]:
         "last_workout_date": last_workout_date,
         "days_since_last_workout": days_since_last_workout,
         "summary_cards": build_summary_cards(historical_data),
+        "last_30_day_workouts": build_last_30_day_workouts(historical_data),
     }
 
 

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -728,6 +728,28 @@ th {
   color: var(--accent-dark);
 }
 
+.recent-workouts {
+  overflow-x: auto;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: 0 8px 20px rgba(19, 24, 38, 0.06);
+}
+
+.recent-workouts table {
+  min-width: 680px;
+}
+
+.recent-workouts th,
+.recent-workouts td {
+  padding: 11px 14px;
+}
+
+.recent-workouts td {
+  font-weight: 600;
+  color: #202738;
+}
+
 .form-card {
   max-width: 720px;
 }

--- a/app/templates/welcome.html
+++ b/app/templates/welcome.html
@@ -46,6 +46,32 @@
           <div class="summary-value">{{ summary_cards.last_30_days.time }}</div>
         </article>
       </div>
+      {% if last_30_day_workouts %}
+        <div class="recent-workouts">
+          <table>
+            <thead>
+              <tr>
+                <th>Workout Date</th>
+                <th>Workout Time</th>
+                <th>Distance</th>
+                <th>Average Speed</th>
+                <th>Total Calories</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for workout in last_30_day_workouts %}
+                <tr>
+                  <td>{{ workout.date }}</td>
+                  <td>{{ workout.time }}</td>
+                  <td>{{ workout.distance }}</td>
+                  <td>{{ workout.average_speed }}</td>
+                  <td>{{ workout.total_calories }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% endif %}
     </section>
 
     <section class="summary-section">

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -372,6 +372,44 @@ def test_welcome_page_shows_days_since_last_workout(monkeypatch, tmp_path) -> No
     assert "http://testserver/static/styles.css" not in text
 
 
+def test_welcome_page_shows_last_30_day_workout_rows(monkeypatch, tmp_path) -> None:
+    _configure_auth(monkeypatch, tmp_path)
+    history_file = tmp_path / "Workout_History.csv"
+    df = app.load_workout_data(
+        [
+            _sample_workout(2, 15, 2026, 0, 30, distance=9.0),
+            _sample_workout(3, 1, 2026, 0, 20, distance=1.0),
+            _sample_workout(3, 5, 2026, 1, 5, distance=2.25),
+            _sample_workout(3, 10, 2026, 0, 45, distance=3.5),
+        ]
+    )
+    df.to_csv(history_file, index=False)
+    monkeypatch.setattr(app, "HISTORY_FILE", history_file)
+    monkeypatch.setattr(app, "current_day", lambda: pd.Timestamp("2026-03-17"))
+
+    client = _client()
+    _log_in(client)
+    response = client.get("/")
+
+    assert response.status_code == 200
+    text = response.text
+    assert "Workout Date" in text
+    assert "Workout Time" in text
+    assert "Average Speed" in text
+    assert "Total Calories" in text
+    assert text.index("2026-03-10") < text.index("2026-03-05")
+    assert text.index("2026-03-05") < text.index("2026-03-01")
+    assert "2026-02-15" not in text
+    assert "45m" in text
+    assert "1h 5m" in text
+    assert "20m" in text
+    assert "3.5" in text
+    assert "2.2" in text
+    assert "1" in text
+    assert "14.2" in text
+    assert "250" in text
+
+
 def test_summarize_window_includes_current_day_in_last_30_days() -> None:
     df = app.load_workout_data(
         [


### PR DESCRIPTION
## Summary
- add welcome dashboard rows for every workout included in the rolling 30-day summary
- display workout date, workout time, distance, average speed, and total calories
- cover the 30-day row behavior with a regression test

## Validation
- uv run pytest