### PR TITLE
[codex] use shared GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
       python-dependencies:
         patterns:
           - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "master"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   ci:
-    uses: adhatcher-org/shared-workflows/.github/workflows/app-ci.yml@e6520622447b5a743aab60bba5dc25c95a32cc69 # v1.0.0
+    uses: adhatcher-org/shared-workflows/.github/workflows/app-ci.yml@8189d4131e5b4b78d9b6f947e4a3bc8a28d4fdc8 # v1.0.1
     with:
       python-version: "3.14"
       dependency-manager: uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,36 +1,26 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  test-and-security:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5.0.0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: "0.11.7"
-
-      - name: Install dependencies
-        run: uv sync --frozen
-
-      - name: Run tests
-        run: make test
-
-      - name: Run coverage
-        run: make coverage
-
-      - name: Run security checks
-        run: make security
+  ci:
+    uses: adhatcher-org/shared-workflows/.github/workflows/app-ci.yml@e6520622447b5a743aab60bba5dc25c95a32cc69 # v1.0.0
+    with:
+      python-version: "3.14"
+      dependency-manager: uv
+      run-lint: false
+      run-typecheck: false
+      run-tests: true
+      run-coverage: true
+      run-security: true
+      run-docker-build: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,6 @@ permissions:
 
 jobs:
   analyze:
-    uses: adhatcher-org/shared-workflows/.github/workflows/codeql.yml@e6520622447b5a743aab60bba5dc25c95a32cc69 # v1.0.0
+    uses: adhatcher-org/shared-workflows/.github/workflows/codeql.yml@8189d4131e5b4b78d9b6f947e4a3bc8a28d4fdc8 # v1.0.1
     with:
       languages: '["python"]'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,13 +2,14 @@ name: CodeQL
 
 on:
   push:
-    branches-ignore:
+    branches:
       - master
   pull_request:
     branches:
       - master
   schedule:
     - cron: "25 4 * * 1"
+  workflow_dispatch:
 
 permissions:
   actions: read
@@ -17,31 +18,6 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze (Python)
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language:
-          - python
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5.0.0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
-        with:
-          languages: ${{ matrix.language }}
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
-
-      - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+    uses: adhatcher-org/shared-workflows/.github/workflows/codeql.yml@e6520622447b5a743aab60bba5dc25c95a32cc69 # v1.0.0
+    with:
+      languages: '["python"]'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ jobs:
     concurrency:
       group: docker-publish
       cancel-in-progress: false
-    uses: adhatcher-org/shared-workflows/.github/workflows/docker-publish.yml@e6520622447b5a743aab60bba5dc25c95a32cc69 # v1.0.0
+    uses: adhatcher-org/shared-workflows/.github/workflows/docker-publish.yml@8189d4131e5b4b78d9b6f947e4a3bc8a28d4fdc8 # v1.0.1
     with:
       package-name: schwinn_stationary_bike
       checkout-ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,108 +1,28 @@
-name: Build and Deploy
+name: Docker Publish
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
   workflow_dispatch:
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
-  build-only:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5.0.0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
-
-      - name: Build Docker image without publishing
-        uses: docker/build-push-action@v7.0.0
-        with:
-          context: .
-          push: false
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-  build-and-push:
-    if: >
-      github.event_name == 'push' ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        github.ref == 'refs/heads/master'
-      )
-    runs-on: ubuntu-latest
+  publish:
+    if: >-
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == github.event.repository.default_branch) ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.ref_name == github.event.repository.default_branch)
     permissions:
       contents: write
       packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%Y.%m.%d')" >> $GITHUB_OUTPUT
-
-      - name: Get latest build number and increment
-        id: tag
-        run: |
-          CURRENT_DATE=${{ steps.date.outputs.date }}
-          LATEST_TAG=$(git ls-remote --tags "https://github.com/${{ github.repository }}.git" | \
-            grep -oP "$CURRENT_DATE-\K\d+" | \
-            sort -n | \
-            tail -1)
-
-          if [ -z "$LATEST_TAG" ]; then
-            BUILD_NUMBER=1
-          else
-            BUILD_NUMBER=$((LATEST_TAG + 1))
-          fi
-
-          NEW_TAG="$CURRENT_DATE-$BUILD_NUMBER"
-          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
-          echo "New tag will be: $NEW_TAG"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
-
-      - name: Login to Container Registry
-        uses: docker/login-action@v4.1.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7.0.0
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.new_tag }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          labels: |
-            org.opencontainers.image.created=${{ steps.date.outputs.date }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    concurrency:
+      group: docker-publish
+      cancel-in-progress: false
+    uses: adhatcher-org/shared-workflows/.github/workflows/docker-publish.yml@e6520622447b5a743aab60bba5dc25c95a32cc69 # v1.0.0
+    with:
+      package-name: schwinn_stationary_bike
+      checkout-ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}


### PR DESCRIPTION
## Summary

- replace duplicated CI, CodeQL, and Docker publishing implementations with pinned reusable workflows
- preserve Python 3.14, UV, test, coverage, security, and multi-platform container behavior
- run CI on both pushes and pull requests to `master`, then publish GHCR images only after successful CI
- enable weekly Dependabot updates for GitHub Actions references

## Impact

Workflow implementation and action versions are now maintained in `adhatcher-org/shared-workflows`. Repository-specific triggers and inputs remain local.

## Validation

- `actionlint` 1.7.12
- YAML parse validation
- `uv lock --check`
- `git diff --check`
